### PR TITLE
gtk2: Fix runCommand SIGCHILD race condition.

### DIFF
--- a/gtk2/style/qt_settings.h
+++ b/gtk2/style/qt_settings.h
@@ -176,6 +176,6 @@ extern QtData     qtSettings;
 
 gboolean qtSettingsInit();
 void qtSettingsSetColors(GtkStyle *style, GtkRcStyle *rc_style);
-bool runCommand(const char* cmd, char** result);
+bool runCommand(const char *cmd, char *const argv[], char** result);
 
 #endif


### PR DESCRIPTION
The SIGCHILD handler gets replaced which could cause race conditions on
fast machines. This patch resets the SIGCHILD handler to the default
before we call popen() and restores it afterwards.

Fixes issue #41.
